### PR TITLE
add github action to automate the release the process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,22 @@
+name: prepare-release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    steps:
+      - name: Check blockers in core
+        run: |
+          blockers=$( gh issue list --search "label:bug" --json url --jq '.[].title' )
+          if [ "${blockers}" != "" ]; then
+              echo "Release blockers in opentelemetry-collector repo: ${blockers}"
+              exit 1
+          fi
+      - name: Check blockers in contrib
+        run: |
+          blockers=$( gh issue list --search "label:bug" --json url --jq '.[].title' --repo open-telemetry/opentelemetry-collector-contrib )
+          if [ "${blockers}" != "" ]; then
+              echo "Release blockers in opentelemetry-collector-contrib repo: ${blockers}"
+              exit 1
+          fi


### PR DESCRIPTION
This PR adds a github action that can be triggered manually to do the following:

- check core for release blockers
- check contrib for release blockers

Signed-off-by: Alex Boten <aboten@lightstep.com>
