### PR TITLE
Codeboten/simplify release part 2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Automation - Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate-stable:
+        required: true
+        description: Release candidate version (stable, like 1.0.0-rc4)
+
+      candidate-beta:
+        required: true
+        description: Release candidate version (beta, like 0.70.0)
+
+      git-commit:
+        require: true
+        description: Changelog update commit (like 2b9639707)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Create a branch named `release/<release-series>` (e.g. `release/v0.45.x`) from the changelog update commit and push to `open-telemetry/opentelemetry-collector`.
+      - name: Push release branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+          COMMIT: "${{ inputs.git-commit }}"
+          CANDIDATE_STABLE: "${{ inputs.candidate-stable }}"
+          CANDIDATE_BETA: "${{ inputs.candidate-beta }}"
+        run: ./.github/workflows/scripts/release-create-branch.sh
+      # Tag all the module groups (stable, beta) with the new release version by running the `make push-tags`
+      # command (e.g. `make push-tags MODSET=stable` and `make push-tags MODSET=beta`). Wait for the new tag build to pass successfully.
+      - name: Push tags for beta modules
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODSET: beta
+        run: ./.github/workflows/scripts/release-push-tags.sh
+      - name: Push tags for stable modules
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODSET: stable
+        run: ./.github/workflows/scripts/release-push-tags.sh

--- a/.github/workflows/scripts/release-create-branch.sh
+++ b/.github/workflows/scripts/release-create-branch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+git config user.name "$GITHUB_ACTOR"
+git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+git checkout "${COMMIT}"
+BRANCH="release/v${CANDIDATE_STABLE}-v${CANDIDATE_BETA}"
+git checkout -b "${BRANCH}"
+git push "git@github.com:${REPO}" "${BRANCH}"

--- a/.github/workflows/scripts/release-push-tags.sh
+++ b/.github/workflows/scripts/release-push-tags.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+git config user.name "$GITHUB_ACTOR"
+git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+make push-tags MODSET="${MODSET}"

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,13 +31,9 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 
 3. Update Contrib to use the latest in development version of Core. Run `make update-otel` in Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft. This is to ensure that the latest core does not break contrib in any way. We’ll update it once more to the final release number later.
 
-4. Create a branch named `release/<release-series>` (e.g. `release/v0.45.x`) from the changelog update commit and push to `open-telemetry/opentelemetry-collector`.
+4. Run the "Automation - Release" action.
 
-5. Tag all the module groups (stable, beta) with the new release version by running the `make push-tags` command (e.g. `make push-tags MODSET=stable` and `make push-tags MODSET=beta`). Wait for the new tag build to pass successfully.
-
-6. The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
-
-7. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description.
+5. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description.
 
 ## Releasing opentelemetry-collector-contrib
 


### PR DESCRIPTION
This changes the release to create the release branch and push tags from a github action.

Signed-off-by: Alex Boten <aboten@lightstep.com>
